### PR TITLE
Added optional size parameter to custom faces endpoint in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Assuming your server lives at `myserver.com`, and you've configured the middlewa
 * `myserver.com/myAvatars/:size/:id`
     * returns an avatar for the provided `id` at the specified `size`
     * size cannot exceed 400px
-* `myserver.com/myAvatars/face/:eyes/:nose/:mouth/:color`
+* `myserver.com/myAvatars/face/:eyes/:nose/:mouth/:color/:size?`
     * Allows you to generate a custom avatar from the specified parts and color
     * e.g. `myserver.com/myAvatars/face/eyes1/nose2/mouth4/DEADBF`
+    * You can also set the size of your custom avatar
+    * e.g. `myserver.com/myAvatars/face/eyes1/nose2/mouth4/DEADBF/300`
 * `myserver.com/myAvatars/list`
     * returns JSON of all valid parts for the custom endpoint above
 

--- a/src/lib/imager.js
+++ b/src/lib/imager.js
@@ -22,9 +22,8 @@ const _parseSize = (size) => {
 };
 
 export const combine = (face, size, callback) => {
-  if (callback) { size = _parseSize(size); }
+  if (size) { size = _parseSize(size); }
   else {
-    callback = size;
     size = { width: maxSize, height: maxSize };
   }
 

--- a/src/routes/avatars.js
+++ b/src/routes/avatars.js
@@ -31,7 +31,7 @@ router.get('/list', function(req, res) {
 });
 
 router.get('/:id', function(req, res, next) {
-  return combine(req.faceParts, function(err, stdout) {
+  return combine(req.faceParts,false, function(err, stdout) {
     return common.sendImage(err, stdout, req, res, next);
   });
 });
@@ -42,7 +42,7 @@ router.get('/:size/:id', function(req, res, next) {
   });
 });
 
-router.get('/face/:eyes/:nose/:mouth/:color', function(req, res, next) {
+router.get('/face/:eyes/:nose/:mouth/:color/:size?', function(req, res, next) {
   let faceParts = { color: '#' + req.params.color };
 
   partTypes.forEach(function(type) {
@@ -61,7 +61,7 @@ router.get('/face/:eyes/:nose/:mouth/:color', function(req, res, next) {
     faceParts[type] = pathFor(type, fileName);
   });
 
-  return combine(faceParts, function(err, stdout) {
+  return combine(faceParts, req.params.size, function(err, stdout) {
     return common.sendImage(err, stdout, req, res, next);
   });
 });

--- a/src/routes/avatars.js
+++ b/src/routes/avatars.js
@@ -31,7 +31,7 @@ router.get('/list', function(req, res) {
 });
 
 router.get('/:id', function(req, res, next) {
-  return combine(req.faceParts,false, function(err, stdout) {
+  return combine(req.faceParts, false, function(err, stdout) {
     return common.sendImage(err, stdout, req, res, next);
   });
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -45,6 +45,18 @@ describe('routing', function() {
       .expect('Content-Type', /image/)
       .end(done);
     });
+
+    it('can manually compose an image with a custom size', function(done) {
+      request.get('/avatars/face/eyes1/nose4/mouth11/bbb/50')
+      .expect(200)
+      .expect('Content-Type', /image/)
+      .parse(parseImage).end(function(err, res) {
+        im(res.body).size(function(_, size) {
+          expect(size).to.eql({ height: 50, width: 50 });
+          done();
+        });
+      });
+    });
   });
 
   describe('v2 avatar list requests', function() {


### PR DESCRIPTION
Hello,
I liked the feature proposed in https://github.com/adorableio/avatars-api-middleware/pull/45 as expressed in #41.

So, here it is almost the same but written in JS according to the new codebase, and with a dedicated SPEC.

```
/avatars/face/eyes4/nose3/mouth7/8e8895
/avatars/face/eyes4/nose3/mouth7/8e8895/300
```
Now both of those are valid addresses.