### PR TITLE
Fix for using Yarn to install as middleware in node.js apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "description": "",
   "engines": {
-    "node": "9.4.x"
+    "node": ">= 9.4.x"
   },
   "scripts": {
     "test": "mocha --exit",


### PR DESCRIPTION
When using `yarn install` - I get this error - 

`error adorable-avatars@0.4.0: The engine "node" is incompatible with this module. Expected version "9.4.x". Got "10.15.0"
`

This PR allows for future versions of node.js to be used. 
